### PR TITLE
Station14のunit testを意図したであろう記述へと修正

### DIFF
--- a/spec/station14/users_request_spec.rb
+++ b/spec/station14/users_request_spec.rb
@@ -2,47 +2,50 @@ require 'rails_helper'
 
 # ユーザー登録周りのテスト
 RSpec.describe User, type: :request do
-    let(:user) { create(:user) }
-    let(:user_params) { attributes_for(:user) }
-    let(:invalid_no_name_user_params) { attributes_for(:user, name: "") }
-    let(:invalid_no_email_user_params) { attributes_for(:user, email: "") }
-    let(:invalid_no_password_user_params) { attributes_for(:user, password: "") }
-    let(:invalid_no_password_confirmation_user_params) { attributes_for(:user, password_confirmation: "") }
+  let(:user) { create(:user) }
+  let(:user_params) { attributes_for(:user) }
+  let(:attributes) { %w[name email password password_confirmation] }
 
-    describe 'Staton14 POST /users' do
-        it '名前・メールアドレス・パスワード・確認用パスワードが全て入力されていて、ユーザー登録ができること' do
-            post user_registration_path, params: { user: user_params }
-            expect(response.status).to eq 302
-        end
+describe 'Staton14 POST /users' do
+    it '必須項目（名前、メールアドレス、パスワード、確認用パスワード）が全て入力されていて、ユーザー登録ができること' do
+        post user_registration_path, params: { user: user_params }
+        expect(response.status).to eq 302
+    end
 
-        it '名前が入力されていないときはユーザー登録ができないこと' do
+    it '必須項目が空文字のときにはユーザー登録ができないこと' do
+        attributes.each do |attr|
+            params = user_params.dup
+            params[attr.to_sym] = ""
             expect do
-                post user_registration_path, params: { user: invalid_no_name_user_params }
-            end.to_not change(User, :count)
-        end
-
-        it 'メールアドレスが入力されていないときはユーザー登録ができないこと' do
-            expect do
-                post user_registration_path, params: { user: invalid_no_email_user_params }
-            end.to_not change(User, :count)
-        end
-
-        it 'パスワードが入力されていないときはユーザー登録ができないこと' do
-            expect do
-                post user_registration_path, params: { user: invalid_no_password_user_params }
-            end.to_not change(User, :count)
-        end
-
-        it '確認用パスワードが入力されていないときはユーザー登録ができないこと' do
-            expect do
-                post user_registration_path, params: { user: invalid_no_password_confirmation_user_params }
-            end.to_not change(User, :count)
-        end
-
-        it 'パスワードと確認用パスワードが一致しないときはユーザー登録ができないこと' do
-            expect do
-                post user_registration_path, params: { user: attributes_for(:user, password: "testuser", password_confirmation: "testuser2") }
+                post user_registration_path, params: { user: params }
             end.to_not change(User, :count)
         end
     end
+
+    it '必須項目がnullのときにはユーザー登録ができないこと' do
+        attributes.each do |attr|
+            params = user_params.dup
+            params[attr.to_sym] = nil
+            expect do
+                post user_registration_path, params: { user: params }
+            end.to_not change(User, :count)
+        end
+    end
+
+    it '必須項目が欠けている時にはユーザー登録ができないこと' do
+        attributes.each do |attr|
+            params = user_params.dup
+            params.delete(attr.to_sym)
+            expect do
+                post user_registration_path, params: { user: params }
+            end.to_not change(User, :count)
+        end
+    end
+
+    it 'パスワードと確認用パスワードが一致しないときはユーザー登録ができないこと' do
+      expect do
+        post user_registration_path, params: { user: attributes_for(:user, password: "testuser", password_confirmation: "testuser2") }
+      end.to_not change(User, :count)
+    end
+  end
 end

--- a/spec/station14/users_request_spec.rb
+++ b/spec/station14/users_request_spec.rb
@@ -16,23 +16,33 @@ RSpec.describe User, type: :request do
         end
 
         it '名前が入力されていないときはユーザー登録ができないこと' do
-            post user_registration_path, params: { user: invalid_no_name_user_params }
-        end.to_not change(User, :count)
+            expect do
+                post user_registration_path, params: { user: invalid_no_name_user_params }
+            end.to_not change(User, :count)
+        end
 
         it 'メールアドレスが入力されていないときはユーザー登録ができないこと' do
-            post user_registration_path, params: { user: invalid_no_email_user_params }
-        end.to_not change(User, :count)
+            expect do
+                post user_registration_path, params: { user: invalid_no_email_user_params }
+            end.to_not change(User, :count)
+        end
 
         it 'パスワードが入力されていないときはユーザー登録ができないこと' do
-            post user_registration_path, params: { user: invalid_no_password_user_params }
-        end.to_not change(User, :count)
+            expect do
+                post user_registration_path, params: { user: invalid_no_password_user_params }
+            end.to_not change(User, :count)
+        end
 
         it '確認用パスワードが入力されていないときはユーザー登録ができないこと' do
-            post user_registration_path, params: { user: invalid_no_password_confirmation_user_params }
-        end.to_not change(User, :count)
+            expect do
+                post user_registration_path, params: { user: invalid_no_password_confirmation_user_params }
+            end.to_not change(User, :count)
+        end
 
         it 'パスワードと確認用パスワードが一致しないときはユーザー登録ができないこと' do
-            post user_registration_path, params: { user: attributes_for(:user, password: "testuser", password_confirmation: "testuser2") }
-        end.to_not change(User, :count)
+            expect do
+                post user_registration_path, params: { user: attributes_for(:user, password: "testuser", password_confirmation: "testuser2") }
+            end.to_not change(User, :count)
+        end
     end
 end


### PR DESCRIPTION
## 概要

### 背景

2022年8月にStation14が面談判定ではなくunit testによる判定になった。
32c82d0 でunit testが追加されたが記述に問題があったが[問い合わせ](https://railwayco.slack.com/archives/C025H2ZK736/p1675914464144959)で判明した。

### 対応

意図したであろう記述に修正した