### PR TITLE
[テストコード修正] buttonタグからinputタグへ変更

### DIFF
--- a/spec/station10/movies_controller_spec.rb
+++ b/spec/station10/movies_controller_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe MoviesController, type: :controller do
 
     context '追加の仕様' do
       it '「座席を予約する」ボタンが存在すること' do
-        expect(response.body).to include("<button").and include("座席を予約する")
+        expect(response.body).to include("<input").and include("座席を予約する")
       end
     end
   end


### PR DESCRIPTION
### Why

Railsでは下記のように `form.submit` を使うとinputタグが生成される。
テストコードでは、buttonタグになっているため、inputタグに置き換え、テストをしたい。

生成前のerb
```rb
<%= form_with url: "/search", method: :get do |form| %>
  <%= form.label :query, "Search for:" %>
  <%= form.text_field :query %>
  <%= form.submit "Search" %>
<% end %>
```

生成されるHTML

```html
<form action="/search" method="get" accept-charset="UTF-8" >
  <label for="query">Search for:</label>
  <input id="query" name="query" type="text" />
  <input name="commit" type="submit" value="Search" data-disable-with="Search" />
</form>
```

refs: https://guides.rubyonrails.org/form_helpers.html#a-generic-search-form

### What

該当のテストコード部分を、buttonタグからinputタグに変更。

