### PR TITLE
[修正] MySQL8.4でmysql_native_password 認証プラグインがデフォルトで無効になったため修正

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,8 +1,8 @@
 services:
   db:
     build:
-      context: ./infra/db
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: ./infra/db/Dockerfile
     environment:
       MYSQL_DATABASE: app_test
       MYSQL_ROOT_PASSWORD: password
@@ -12,7 +12,6 @@ services:
       - "3306:3306"
     volumes:
       - rails-railway-stations-volume:/var/lib/mysql
-
   web:
     build:
       context: .
@@ -21,6 +20,7 @@ services:
     volumes:
       - .:/app
       - bundle:/usr/local/bundle
+      - rails-railway-stations-volume:/var/lib/mysql
     ports:
       - "3000:3000"
     links:

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,6 +5,10 @@ default: &default
   username: root
   password: "password"
   host: db
+  sslverify: true
+  sslca: /var/lib/mysql/ca.pem
+  sslcert: /var/lib/mysql/client-cert.pem
+  sslkey: /var/lib/mysql/client-key.pem
 
 development:
   <<: *default

--- a/infra/db/Dockerfile
+++ b/infra/db/Dockerfile
@@ -1,5 +1,7 @@
-FROM mysql:8.4.1
-# FROM --platform=linux/x86_64 mysql:5.7
+FROM mysql:8.4.1-oraclelinux9
 
-# COPY init /docker-entrypoint-initdb.d
+# Set MySQL configuration (optional if you have custom config)
+COPY infra/db/conf/my.cnf /etc/mysql/my.cnf
+
+# Expose MySQL port
 EXPOSE 3306

--- a/infra/db/conf/my.cnf
+++ b/infra/db/conf/my.cnf
@@ -8,8 +8,9 @@ collation-server = utf8mb4_bin
 default-time-zone = SYSTEM
 log_timestamps = SYSTEM
 
-# デフォルト認証プラグインの設定
-default-authentication-plugin = mysql_native_password
+require-secure-transport = ON
+tls-version=TLSv1.2,TLSv1.3
+auto_generate_certs = ON
 
 # エラーログの設定
 log-error = /var/log/mysql/mysql-error.log

--- a/infra/web/Dockerfile
+++ b/infra/web/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 # このDockerfileでgemのインストールやyarnによるパッケージのインストールをしていないのは、
 # ログインなどの処理を挟む必要があるため。
 COPY Gemfile /app/Gemfile
-# COPY Gemfile.lock /app/Gemfile.lock
+COPY Gemfile.lock /app/Gemfile.lock
 COPY . /app
 
 COPY entrypoint.sh /usr/bin/


### PR DESCRIPTION
### Why

[mysql_native_password 認証プラグイン](https://dev.mysql.com/doc/refman/8.4/en/native-pluggable-authentication.html)がデフォルトで無効になったため、環境構築に失敗する。
https://dev.mysql.com/doc/relnotes/mysql/8.4/en/news-8-4-0.html#mysqld-8-4-0-deprecation-removal
mysql_native_password 認証プラグインを脱し、今後mysql2プラグインではなくtrilogyプラグインになる可能性があるため、先を見越してTLS通信するようにもしたい。
https://github.com/trilogy-libraries/trilogy/issues/26

### What

- mysql_native_password 認証プラグインに依存しないように設定を変更
- TLS通信をするようにRails, MySQLの設定を変更

### 関連するフォーラム

https://github.com/TechTrain-Community/RailwayForum/discussions/733