### PR TITLE
fix(station09): スケジュール表示のテストを index から show アクションに修正

### DIFF
--- a/spec/station09/movies_controller_spec.rb
+++ b/spec/station09/movies_controller_spec.rb
@@ -3,11 +3,11 @@ RSpec::Matchers.define_negated_matcher :not_include, :include
 
 RSpec.describe Admin::MoviesController, type: :controller do
   render_views
-  describe 'Station9 GET /admin/movies' do
+  describe 'Station9 GET /admin/movies/:id' do
     let!(:movies) { create_list(:movie, 3) }
     let!(:schedules) { create_list(:schedule, 3, movie_id: movies.first.id) }
     before do
-      get :index
+      get :show, params: { id: movies.first.id }
     end
 
     it 'movies(:id)に対応するscheduleを表示していること' do


### PR DESCRIPTION
## 問題

`spec/station09/movies_controller_spec.rb` が `GET /admin/movies`（index）に対してスケジュールの表示を確認していますが、クリア条件および問題文には以下のように記載されています。

> `GET /admin/movies/:id` movies(:id)に対応するscheduleを表示していること

## 変更内容

`spec/station09/movies_controller_spec.rb` のみ修正:

```diff
- describe 'Station9 GET /admin/movies' do
+ describe 'Station9 GET /admin/movies/:id' do
    before do
-     get :index
+     get :show, params: { id: movies.first.id }
    end
```

## 代替案

もしくは、問題文としてスケジュールの表示を追加する記載があればよいかと思いました。